### PR TITLE
fix: remove rom extension from nextui images

### DIFF
--- a/src/format/nextui.ts
+++ b/src/format/nextui.ts
@@ -15,7 +15,8 @@ export async function useSeparateArtworks(_options: Options) {
 }
 
 export async function getArtPath(filePath: string, _machine: string, _type?: ArtType) {
-  return path.join(path.dirname(filePath), mediaFolder, `${path.basename(filePath)}.png`);
+  const fileName = path.basename(filePath, path.extname(filePath));
+  return path.join(path.dirname(filePath), mediaFolder, `${fileName}.png`);
 }
 
 export async function exportArtwork(


### PR DESCRIPTION
I made a quick fix to remove rom file extensions from images when in nextui output mode.

minui requires the following structure:

```
romFolder/
│── .res/
│   └── AwesomeGame.zip.png
└── AwesomeGame.zip
```

While nextui requires the following:

```
romFolder/
│── .media/
│   └── AwesomeGame.png
└── AwesomeGame.zip
```