### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ WORKDIR /app
 # Copy project files
 COPY . .
 
-# Install dependencies & build the project
-RUN npm ci && npm run build && npm install -g .
+# Install dependencies, build and install the CLI
+RUN npm install && npm run build && npm install -g .
 
 # Copy the entrypoint script
 COPY scripts/entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-bullseye
+
+# Install dependencies
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+# Install Ollama
+RUN curl -fsSL https://ollama.com/install.sh | sh
+
+# Set working directory
+WORKDIR /app
+
+# Copy project files
+COPY . .
+
+# Install dependencies & build the project
+RUN npm ci && npm run build && npm install -g .
+
+# Copy the entrypoint script
+COPY scripts/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Use the script as the entrypoint
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Artwork scraper for [MinUI](https://github.com/shauninman/MinUI), [NextUI](https
 - Optionally uses local AI with [Ollama](https://ollama.com/) for better boxart matching
 - No configuration needed
 
-## Installation
+## Getting started
+
+### Running Locally
 
 Requires [Node.js](https://nodejs.org/), and optionally [Ollama](https://ollama.com/) for AI matching. You need to install these to be able to use the scraper.
 
@@ -31,18 +33,46 @@ Install the CLI globally by opening a terminal and running the following command
 npm install -g @sinedied/mini-scraper
 ```
 
-## Usage
-
 To run the scraper, open a terminal and use the following command:
 
 ```bash
 mscraper <rompath> [options]
 ```
 
-> [!TIP]
-> Max width must be adjusted depending of the device and output format, the default works well for Trimui Brick. For 640x480 devices, try with `--width 200`.
+Explanation:
 
-### Options
+- `<rompath>`: This is the path to the directory containing your ROMs.
+- `[options]`: Replace this with the command-line arguments to be passed to the scraper.
+
+### Running with Docker
+
+Using the Docker image is the easiest way to run the scraper without needing to install Node.js or Ollama.
+
+Firstly you will need to have Docker installed on your system. You can download and install Docker from the [official website](https://www.docker.com/).
+
+Once this is done build the Docker image by running the following command in the project directory:
+
+```bash
+docker build -t mini-scraper .
+```
+
+Then, you can run the scraper with the following command:
+
+```bash
+docker run --rm -v <rompath>:/roms mini-scraper /roms [options]
+```
+
+Explanation:
+
+- `--rm`: This removes the container after it has finished running.
+- `-v <rompath>:/roms`: This mounts your ROMs directory to the /roms directory inside the container.  Replace <rompath> with the actual path to your ROMs.
+- `mini-scraper`: This is the name of the Docker image.
+- `/roms`: This is the directory inside the container where the ROMs are mounted.
+- `[options]`: Replace this with the command-line arguments to be passed to the scraper.
+
+## Options
+
+When running the scraper, you can pass the following options:
 
 - `-w, --width <size>`: Max width of the image (default: 300)
 - `-h, --height <size>`: Max height of the image
@@ -55,6 +85,9 @@ mscraper <rompath> [options]
 - `--cleanup`: Removes all scraped images in target folder
 - `--verbose`: Show detailed logs
 - `-v, --version`: Show current version
+
+> [!TIP]
+> Max width must be adjusted depending of the device and output format, the default works well for Trimui Brick. For 640x480 devices, try with `--width 200`.
 
 ## Example
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Save the arguments
+params=("$@")
+
+# Check if the arguments contain "-a" and get the model name
+model_name="gemma2:2b"
+model_required=false
+for arg in "$@"; do
+    if [[ "$arg" == "-a" || "$arg" == "--ai" ]]; then
+        model_required=true
+    elif [[ "$arg" == "-m" || "$arg" == "--ai-model" ]]; then
+        model_name="$2"
+    fi
+    shift
+done
+
+# Start Ollama and download the model
+if $model_required; then
+    # Start Ollama in the background
+    ollama serve &
+
+    # Wait for Ollama to be ready
+    until curl -s http://localhost:11434/api/tags > /dev/null; do
+        echo "Waiting for Ollama to start..."
+        sleep 2
+    done
+
+    # Download the model
+    ollama pull "$model_name"
+fi
+
+# Run mscraper with any provided arguments
+exec mscraper "${params[@]}"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -3,12 +3,12 @@
 # Exit on error
 set -e
 
-# Save the arguments
+# Variables
 params=("$@")
-
-# Check if the arguments contain "-a" and get the model name
 model_name="gemma2:2b"
 model_required=false
+
+# Check if AI is required and get the model name
 for arg in "$@"; do
     if [[ "$arg" == "-a" || "$arg" == "--ai" ]]; then
         model_required=true
@@ -18,7 +18,7 @@ for arg in "$@"; do
     shift
 done
 
-# Start Ollama and download the model
+# If AI is required, start Ollama and download the model
 if $model_required; then
     # Start Ollama in the background
     ollama serve &
@@ -33,5 +33,5 @@ if $model_required; then
     ollama pull "$model_name"
 fi
 
-# Run mscraper with any provided arguments
+# Run mscraper with the provided arguments
 exec mscraper "${params[@]}"


### PR DESCRIPTION
Hi I wasn’t sure if you’d be interested, but I created a Dockerfile to simplify running the scraper without needing to install dependencies manually.

Once built, the container includes mini-scraper and ollama, and it downloads the model automatically. I find this makes it much easier to use as long as Docker is installed.

I’ve also updated the README to include instructions for using it with Docker.