### PR TITLE
remove MinUI "XX)" ordering from sanitized name

### DIFF
--- a/src/libretro.ts
+++ b/src/libretro.ts
@@ -186,7 +186,7 @@ export async function findArtUrl(
 }
 
 export function santizeName(name: string) {
-  return name.replaceAll(/[&*/:`<>?|"]/g, '_');
+  return name.replace(/^[0-9]+\)\s*/g, '').replaceAll(/[&*/:`<>?|"]/g, '_');
 }
 
 export function getArtTypes(options: Options) {


### PR DESCRIPTION
MinUI (and maybe others) allows ROMs to be manually sorted by adding ```XX)``` in front of the filename, where XX can be any number.

This caused mini-scraper to not match any roms. This sanitizes them away.