### PR TITLE
Improve subtitle handling in matching logic

### DIFF
--- a/src/libretro.ts
+++ b/src/libretro.ts
@@ -163,8 +163,13 @@ export async function findArtUrl(
   match = await findMatch(strippedName);
   if (match) return match;
 
-  // Try searching after removing substitles in the name
-  strippedName = strippedName.split(' - ')[0].trim();
+  // Try searching after removing substitles using '- '
+  strippedName = strippedName.split('- ')[0].trim();
+  match = await findMatch(strippedName);
+  if (match) return match;
+
+  // Try searching after removing substitles using ': '
+  strippedName = strippedName.split(': ')[0].trim();
   match = await findMatch(strippedName);
   if (match) return match;
 

--- a/src/libretro.ts
+++ b/src/libretro.ts
@@ -163,13 +163,13 @@ export async function findArtUrl(
   match = await findMatch(strippedName);
   if (match) return match;
 
-  // Try searching after removing substitles using '- '
-  strippedName = strippedName.split('- ')[0].trim();
+  // Try searching after removing substitles using ': '
+  strippedName = strippedName.split(': ')[0].trim();
   match = await findMatch(strippedName);
   if (match) return match;
 
-  // Try searching after removing substitles using ': '
-  strippedName = strippedName.split(': ')[0].trim();
+  // Try searching after removing substitles using '- '
+  strippedName = strippedName.split('- ')[0].trim();
   match = await findMatch(strippedName);
   if (match) return match;
 


### PR DESCRIPTION
This PR makes a small improvement to how subtitles are handled when searching for matching artwork.

- Previously, the scraper looked for " - " (with spaces) when removing subtitles, but I found this caused issues for titles where : had been replaced with - (i.e. Golden Sun- The Lost Age).
- Now, it looks for "- " (without the leading space) to improve matching.
- Additionally, it now removes subtitles that use ": " as well.