### PR TITLE
Improve fuzzy matching with Cosine Similarity & Jaro-Winkler

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "fast-glob": "^3.3.3",
     "fast-png": "^6.3.0",
     "fastest-levenshtein": "^1.0.16",
+    "string-comparison": "^1.3.0",
     "jimp": "^1.6.0",
     "ollama": "^0.5.13",
     "update-notifier": "^7.3.1"

--- a/src/libretro.ts
+++ b/src/libretro.ts
@@ -176,14 +176,14 @@ export async function findArtUrl(
   match = await findMatch(strippedName);
   if (match) return match;
 
-  // Try searching after removing substitles in the name
-  strippedName = strippedName.split(' - ')[0].trim();
-  match = await findMatch(strippedName);
-  if (match) return match;
-
   // Try searching using findFuzzyMatch
   strippedName = fileName.replaceAll(/(\(.*?\)|\[.*?])/g, '').trim();
   match = await findFuzzyMatch(strippedName);
+  if (match) return match;
+
+  // Try searching after removing substitles in the name
+  strippedName = strippedName.split(' - ')[0].trim();
+  match = await findMatch(strippedName);
   if (match) return match;
 
   // Try with fallback machines

--- a/src/libretro.ts
+++ b/src/libretro.ts
@@ -167,7 +167,6 @@ export async function findArtUrl(
       .sort((a, b) => b.similarity - a.similarity)
       .slice(0, 25)
       .map(({ art }) => art);
-    console.log(`Num of results: ${cosineMatches.length + jaroMatches.length}`);
     const matches = [...cosineMatches, ...jaroMatches];
     if (matches.length > 0) {
       const bestMatch = await findBestMatch(name, fileName, matches, options);

--- a/src/libretro.ts
+++ b/src/libretro.ts
@@ -4,9 +4,6 @@ import fs from 'node:fs/promises';
 import createDebug from 'debug';
 import glob from 'fast-glob';
 import stringComparison from "string-comparison";
-
-const cosine = stringComparison.cosine;
-const jaroWinkler = stringComparison.jaroWinkler;
 import { ArtTypeOption, type Options } from './options.js';
 import { findBestMatch } from './matcher.js';
 import { stats } from './stats.js';
@@ -157,14 +154,10 @@ export async function findArtUrl(
     return undefined;
   };
 
-
-
-
   const findFuzzyMatch = async (name: string) => {
-    const cosineMatches = arts.filter((a) => cosine.similarity(santizeName(name), a) >= 0.80);
-    const jaroMatches = arts.filter((a) => jaroWinkler.similarity(santizeName(name), a) >= 0.85);
-    const matches = [...cosineMatches, ...jaroMatches].slice(0, 100);
-    console.log(matches);
+    const cosineMatches = arts.filter((a) => stringComparison.cosine.similarity(santizeName(name), a) >= 0.80);
+    const jaroMatches = arts.filter((a) => stringComparison.jaroWinkler.similarity(santizeName(name), a) >= 0.85);
+    const matches = [...cosineMatches, ...jaroMatches].slice(0, 250);
     if (matches.length > 0) {
       const bestMatch = await findBestMatch(name, fileName, matches, options);
       return `${baseUrl}${machine}/${type}/${bestMatch}`;
@@ -172,8 +165,6 @@ export async function findArtUrl(
 
     return undefined;
   };
-
-
 
   // Try searching after removing (...) and [...] in the name
   let strippedName = fileName.replaceAll(/(\(.*?\)|\[.*?])/g, '').trim();
@@ -194,7 +185,6 @@ export async function findArtUrl(
   strippedName = fileName.replaceAll(/(\(.*?\)|\[.*?])/g, '').trim();
   match = await findFuzzyMatch(strippedName);
   if (match) return match;
-
 
   // Try with fallback machines
   if (!fallback) return undefined;

--- a/src/libretro.ts
+++ b/src/libretro.ts
@@ -158,15 +158,15 @@ export async function findArtUrl(
     const strippedArts = arts.map((a) => a.replaceAll(/(\(.*?\)|\[.*?])/g, '').trim());
     const cosineMatches = strippedArts
       .map((a) => ({ art: a, similarity: stringComparison.cosine.similarity(santizeName(name), a) }))
-      .filter(({ similarity }) => similarity >= 0.75)
+      .filter(({ similarity }) => similarity >= 0.80)
       .sort((a, b) => b.similarity - a.similarity)
-      .slice(0, 20)
+      .slice(0, 25)
       .map(({ art }) => art);
     const jaroMatches = strippedArts
       .map((a) => ({ art: a, similarity: stringComparison.jaroWinkler.similarity(santizeName(name), a) }))
       .filter(({ similarity }) => similarity >= 0.75)
       .sort((a, b) => b.similarity - a.similarity)
-      .slice(0, 20)
+      .slice(0, 25)
       .map(({ art }) => art);
       const matches: string[] = [];
       strippedArts.forEach((strippedArt, index) => {
@@ -174,7 +174,6 @@ export async function findArtUrl(
           matches.push(arts[index]);
         }
       });
-    console.log(matches);
     if (matches.length > 0) {
       const bestMatch = await findBestMatch(name, fileName, matches, options);
       return `${baseUrl}${machine}/${type}/${bestMatch}`;

--- a/src/libretro.ts
+++ b/src/libretro.ts
@@ -187,7 +187,6 @@ export async function findArtUrl(
   if (match) return match;
 
   // Try searching using findFuzzyMatch
-  strippedName = fileName.replaceAll(/(\(.*?\)|\[.*?])/g, '').trim();
   match = await findFuzzyMatch(strippedName);
   if (match) return match;
 


### PR DESCRIPTION
This PR makes an improvement to the scraper's ability to find boxart by adding fuzzy matching using the string-comparison library. It now uses:

- Cosine Similarity: Finds matches based on shared patterns in words.
- Jaro-Winkler: Detects small differences, like typos or swapped letters, which is good for typo correction and minor differences.

I tested it on about 250 ROMs and found that when the filenames differed (e.g. typos, or reordered words), a match was still found, almost doubling the number of matches.