### PR TITLE
fix: encode URIs in `loadImage`

### DIFF
--- a/src/image.ts
+++ b/src/image.ts
@@ -12,6 +12,7 @@ export type Size = {
 };
 
 export async function loadImage(url: string) {
+  url = encodeURI(url);
   try {
     return await Jimp.read(url);
   } catch (error_: unknown) {


### PR DESCRIPTION
Images with URI special characters will fail with a 400 due to not being escaped before being requested.

Jimp also makes a raw `fetch` internally, so I have escaped it before anything else uses it, the only 'negative' downside is that failure and debug logging will show an encoded url rather than a raw one.

Unfortunately I can't find a test case for this again (without truncating my entire library), but did experience it happening where a partial/AI match had a special character in it.