### PR TITLE
fix: move NES after DS, since it has the shorter alias

### DIFF
--- a/src/machines.ts
+++ b/src/machines.ts
@@ -37,10 +37,6 @@ export const machines: Record<string, Machine> = {
     extensions: ['fds', 'zip'],
     alias: ['FDS', 'Family Computer Disk System', 'Famicom Disk System']
   },
-  'Nintendo - Nintendo Entertainment System': {
-    extensions: ['nes', 'zip'],
-    alias: ['NES', 'FC', 'Famicom', 'Nintendo']
-  },
   'Nintendo - Nintendo DSi': {
     extensions: ['dsi', 'zip'],
     alias: ['DSi', 'Nintendo DSi'],
@@ -49,6 +45,10 @@ export const machines: Record<string, Machine> = {
   'Nintendo - Nintendo DS': {
     extensions: ['nds', 'zip'],
     alias: ['DS', 'Nintendo DS']
+  },
+  'Nintendo - Nintendo Entertainment System': {
+    extensions: ['nes', 'zip'],
+    alias: ['NES', 'FC', 'Famicom', 'Nintendo']
   },
   'Nintendo - Pokemon Mini': {
     extensions: ['pm', 'min', 'zip'],


### PR DESCRIPTION
Machines are compared in the order they are in, and as such NES with the alias `Nintendo` should come after Nintendo DS / DSi, or it will match the NES before the longer DS.

This does highlight an underlying issue, and maybe `getMachine` should find the 'longest' match (or perhaps even use matcher?).

I couldn't find a test case for this one, because weirdly enough, when i tried isolating the ROMs which gave me issues, they worked, somehow, and  I don't want to truncate my main library.

![WindowsTerminal_Y9cJ11wVqx](https://github.com/user-attachments/assets/da8d6271-838d-4982-bd62-89d50d1f8683)
 