### PR TITLE
fix(cleanup): scope artwork cleanup to the selected ROM folders

### DIFF
--- a/src/format/anbernic.ts
+++ b/src/format/anbernic.ts
@@ -39,10 +39,15 @@ export async function exportArtwork(
   return true;
 }
 
-export async function cleanupArtwork(targetPath: string, _romFolders: string[], _options: Options) {
-  const imgsFolders = await glob([`**/${imgsFolder}`], { onlyDirectories: true, cwd: targetPath });
-  await Promise.all(imgsFolders.map(async (imgsFolder) => fs.rm(imgsFolder, { recursive: true })));
-  console.info(`Removed ${imgsFolders.length} ${imgsFolder} folders`);
+export async function cleanupArtwork(targetPath: string, romFolders: string[], _options: Options) {
+  let removed = 0;
+  for (const romFolder of romFolders) {
+    const folders = await glob([`${romFolder}/**/${imgsFolder}`], { onlyDirectories: true, cwd: targetPath });
+    await Promise.all(folders.map(async (folder) => fs.rm(path.join(targetPath, folder), { recursive: true })));
+    removed += folders.length;
+  }
+
+  console.info(`Removed ${removed} ${imgsFolder} folders`);
 }
 
 const anbernic = {

--- a/src/format/minui.ts
+++ b/src/format/minui.ts
@@ -38,10 +38,15 @@ export async function exportArtwork(
   return true;
 }
 
-export async function cleanupArtwork(targetPath: string, _romFolders: string[], _options: Options) {
-  const resFolders = await glob([`**/${resFolder}`], { onlyDirectories: true, cwd: targetPath });
-  await Promise.all(resFolders.map(async (resFolder) => fs.rm(resFolder, { recursive: true })));
-  console.info(`Removed ${resFolders.length} ${resFolder} folders`);
+export async function cleanupArtwork(targetPath: string, romFolders: string[], _options: Options) {
+  let removed = 0;
+  for (const romFolder of romFolders) {
+    const folders = await glob([`${romFolder}/**/${resFolder}`], { onlyDirectories: true, cwd: targetPath });
+    await Promise.all(folders.map(async (folder) => fs.rm(path.join(targetPath, folder), { recursive: true })));
+    removed += folders.length;
+  }
+
+  console.info(`Removed ${removed} ${resFolder} folders`);
 }
 
 const minui = {

--- a/src/format/nextui.ts
+++ b/src/format/nextui.ts
@@ -39,10 +39,15 @@ export async function exportArtwork(
   return true;
 }
 
-export async function cleanupArtwork(targetPath: string, _romFolders: string[], _options: Options) {
-  const mediaFolders = await glob([`**/${mediaFolder}`], { onlyDirectories: true, cwd: targetPath });
-  await Promise.all(mediaFolders.map(async (mediaFolder) => fs.rm(mediaFolder, { recursive: true })));
-  console.info(`Removed ${mediaFolders.length} ${mediaFolder} folders`);
+export async function cleanupArtwork(targetPath: string, romFolders: string[], _options: Options) {
+  let removed = 0;
+  for (const romFolder of romFolders) {
+    const folders = await glob([`${romFolder}/**/${mediaFolder}`], { onlyDirectories: true, cwd: targetPath });
+    await Promise.all(folders.map(async (folder) => fs.rm(path.join(targetPath, folder), { recursive: true })));
+    removed += folders.length;
+  }
+
+  console.info(`Removed ${removed} ${mediaFolder} folders`);
 }
 
 const nextui = {


### PR DESCRIPTION
## Problem

`cleanupArtwork` (run via `--cleanup`) globbed **every** matching art folder under the working directory (e.g. `**/Imgs`, `**/.res`, `**/.media`) and ignored the `romFolders` argument it receives.

As a result, cleaning a **single** system deleted the art folders of **all** systems. For example, running cleanup on `Roms/GB` sets the working directory to `Roms/` and the glob then matches `FC/Imgs`, `SFC/Imgs`, etc., wiping their artwork too.

This was flagged during review of the OnionOS format PR (#16); the Onion format reuses the Anbernic layout, so it's affected as well.

## Fix

Scope the cleanup glob to each selected ROM folder (`<romFolder>/**/<artFolder>`), which:
- only removes art folders inside the systems actually being cleaned;
- still handles nested ROM subfolders (globstar matches zero or more segments);
- resolves removal paths against `targetPath` (`path.join`) so library callers passing a non-`.` target are safe.

Applies to **minui** (`.res`), **nextui** (`.media`) and **anbernic** (`Imgs`). `muos` already scoped cleanup to `romFolders` and is unchanged.

## Validation

- `npm run build` and `npm run lint` pass (only pre-existing `libretro.ts` warnings).
- Manual test: cleaning `GB` removes `GB/Imgs` and the nested `GB/RPG/Imgs`, while `FC/Imgs` (another system) is preserved.
