### PR TITLE
ci: bump actions/checkout and actions/setup-node to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - run: git config --global core.autocrlf false  # Preserve line endings on Windows
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
     - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         persist-credentials: false
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v7
       with:
         node-version: 20
     - run: |


### PR DESCRIPTION
Bumps the GitHub Actions used in CI and release to their current major version (v7):

- `actions/checkout@v4` → `@v7`
- `actions/setup-node@v4` → `@v7`

The project's tested Node version stays at **20** (unchanged in the CI matrix and `engines`). The runner-Node deprecation that motivated the v7 releases only affects the actions' own runtime, not the `node-version` they install for the build.

No breaking change applies here: CI uses `pull_request` (not `pull_request_target`, the target of the v5-v7 checkout security change), and `release.yml` keeps `persist-credentials: false`.
