### PR TITLE
fix(cleanup): match ROM folders with glob-special characters

### DIFF
--- a/src/format/anbernic.ts
+++ b/src/format/anbernic.ts
@@ -42,8 +42,11 @@ export async function exportArtwork(
 export async function cleanupArtwork(targetPath: string, romFolders: string[], _options: Options) {
   let removed = 0;
   for (const romFolder of romFolders) {
-    const folders = await glob([`${romFolder}/**/${imgsFolder}`], { onlyDirectories: true, cwd: targetPath });
-    await Promise.all(folders.map(async (folder) => fs.rm(path.join(targetPath, folder), { recursive: true })));
+    // Use the ROM folder as the glob's cwd (a real path) rather than interpolating its name
+    // into the pattern, so names with glob-special characters (e.g. "Game Boy (GB)") still match.
+    const romPath = path.join(targetPath, romFolder);
+    const folders = await glob([`**/${imgsFolder}`], { onlyDirectories: true, cwd: romPath });
+    await Promise.all(folders.map(async (folder) => fs.rm(path.join(romPath, folder), { recursive: true })));
     removed += folders.length;
   }
 

--- a/src/format/minui.ts
+++ b/src/format/minui.ts
@@ -41,8 +41,11 @@ export async function exportArtwork(
 export async function cleanupArtwork(targetPath: string, romFolders: string[], _options: Options) {
   let removed = 0;
   for (const romFolder of romFolders) {
-    const folders = await glob([`${romFolder}/**/${resFolder}`], { onlyDirectories: true, cwd: targetPath });
-    await Promise.all(folders.map(async (folder) => fs.rm(path.join(targetPath, folder), { recursive: true })));
+    // Use the ROM folder as the glob's cwd (a real path) rather than interpolating its name
+    // into the pattern, so names with glob-special characters (e.g. "Game Boy (GB)") still match.
+    const romPath = path.join(targetPath, romFolder);
+    const folders = await glob([`**/${resFolder}`], { onlyDirectories: true, cwd: romPath });
+    await Promise.all(folders.map(async (folder) => fs.rm(path.join(romPath, folder), { recursive: true })));
     removed += folders.length;
   }
 

--- a/src/format/nextui.ts
+++ b/src/format/nextui.ts
@@ -42,8 +42,11 @@ export async function exportArtwork(
 export async function cleanupArtwork(targetPath: string, romFolders: string[], _options: Options) {
   let removed = 0;
   for (const romFolder of romFolders) {
-    const folders = await glob([`${romFolder}/**/${mediaFolder}`], { onlyDirectories: true, cwd: targetPath });
-    await Promise.all(folders.map(async (folder) => fs.rm(path.join(targetPath, folder), { recursive: true })));
+    // Use the ROM folder as the glob's cwd (a real path) rather than interpolating its name
+    // into the pattern, so names with glob-special characters (e.g. "Game Boy (GB)") still match.
+    const romPath = path.join(targetPath, romFolder);
+    const folders = await glob([`**/${mediaFolder}`], { onlyDirectories: true, cwd: romPath });
+    await Promise.all(folders.map(async (folder) => fs.rm(path.join(romPath, folder), { recursive: true })));
     removed += folders.length;
   }
 


### PR DESCRIPTION
Follow-up regression fix to #24.

## Problem
The cleanup scoping introduced in #24 interpolated the ROM folder name directly into the glob pattern (`<romFolder>/**/<artFolder>`). Folder names containing glob metacharacters — e.g. `Game Boy (GB)` or `Colony Wars (France)` — were then treated as glob groups and matched nothing, so their art folders (`.res`/`.media`/`Imgs`) were never cleaned.

## Fix
Use the ROM folder as the glob's **cwd** (a real filesystem path, no glob interpretation) and glob `**/<artFolder>` within it. Handles special characters, direct and nested art folders, and stays scoped to the selected system. Applies to minui, nextui and anbernic (muos already scoped differently).

## Validation
- Build + lint pass.
- End-to-end on the repo's `test/` fixture: `--cleanup` now removes all 9 `.res` folders including those under `Game Boy (GB)` (direct + nested) and `PS/Colony Wars (France)`, while ROMs and subfolders are preserved. Previously those parenthesised folders were skipped.